### PR TITLE
Call M5.Display.waitDisplay() before entering deep sleep.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,11 +64,9 @@ void setup() {
     }
   }
 
-  M5.Display.waitDisplay();
-
   // Enter into deep sleep
   M5.Log(esp_log_level_t::ESP_LOG_INFO, "Deep sleep start\n");
-  esp_deep_sleep_start();
+  M5.Power.deepSleep();
 }
 
 void loop() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,8 @@ void setup() {
     }
   }
 
+  M5.Display.waitDisplay();
+
   // Enter into deep sleep
   M5.Log(esp_log_level_t::ESP_LOG_INFO, "Deep sleep start\n");
   esp_deep_sleep_start();


### PR DESCRIPTION
This PR fixes a problem with M5Paper not displaying images.

Not tested on M5PaperS3 (sorry, I don't own it).
